### PR TITLE
Pdf document crash

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -214,7 +214,7 @@ dependencies {
     implementation ("org.apache.poi:poi-ooxml:5.3.0")
     implementation ("org.apache.poi:poi-scratchpad:5.3.0")
     implementation ("org.apache.odftoolkit:simple-odf:0.8.2-incubating")
-    implementation ("com.itextpdf:itext7-core:7.1.15")
+    implementation ("com.tom-roush:pdfbox-android:2.0.27.0")
 }
 
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -214,7 +214,7 @@ dependencies {
     implementation ("org.apache.poi:poi-ooxml:5.3.0")
     implementation ("org.apache.poi:poi-scratchpad:5.3.0")
     implementation ("org.apache.odftoolkit:simple-odf:0.8.2-incubating")
-    implementation ("com.itextpdf:itext7-core:8.0.5")
+    implementation ("com.itextpdf:itext7-core:7.1.15")
 }
 
 


### PR DESCRIPTION
This pull request replaces iText with PDFBox-Android. The iText version previously used incur in a crash in some PDF files, this was resolved by downgrading it. Anyways just notice the author metatag doesnt get removed, you can only append text to the original author metadata witch is not good.

Replacing with PDFBox solves this.